### PR TITLE
File object support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,3 +13,4 @@ Planned development for multiformat
 - Add page option to Document.generate_image()
 - Add method to define the metadata for a PDF
 - No fill rectangles
+- Validate file_object parameters on generate methods

--- a/multiformat/generate_image.py
+++ b/multiformat/generate_image.py
@@ -108,10 +108,13 @@ class _Image:
         self.draw.line(
             [(x3, y3), (x, y)], fill=border_color, width=border_width)
 
-    def save(self):
+    def save(self, file_object=None):
         # Save the image to a file
         if self.output_dimensions:
             self.image = self.image.resize(
                 self.output_dimensions, resample=ImagePIL.ANTIALIAS)
-        self.image.save("{}.{}".format(self.file_name, self.image_format),
-                        self.image_format)
+        if file_object:
+            self.image.save(fp=file_object, format=self.image_format)
+        else:
+            self.image.save("{}.{}".format(self.file_name, self.image_format),
+                            self.image_format)

--- a/multiformat/generate_pdf.py
+++ b/multiformat/generate_pdf.py
@@ -22,13 +22,20 @@ from reportlab.pdfbase.ttfonts import TTFont
 
 class _PDF:
     # Generate a PDF with the reportlab open source toolkit.
-    def __init__(self, file_name, document_size, orientation):
+    def __init__(self, file_name, document_size, orientation,
+                 file_object=None):
         if document_size == "letter":
             standard_doc_size = letter
         elif document_size == "a4":
             standard_doc_size = A4
-        self.pdf = canvas.Canvas(
-            "{}.pdf".format(file_name), pagesize=standard_doc_size, bottomup=0)
+        if file_object:
+            self.pdf = canvas.Canvas(
+                file_object, pagesize=standard_doc_size, bottomup=0)
+        else:
+            self.pdf = canvas.Canvas(
+                "{}.pdf".format(file_name),
+                pagesize=standard_doc_size,
+                bottomup=0)
         self.loaded_fonts = [
             "Courier",
             "Courier-Bold",

--- a/multiformat/multiformat.py
+++ b/multiformat/multiformat.py
@@ -230,7 +230,11 @@ class Document:
                 pdf.new_page()
         pdf.save()
 
-    def generate_image(self, file_name, image_format, size=None):
+    def generate_image(self,
+                       file_name,
+                       image_format,
+                       size=None,
+                       file_object=None):
         """Generate the document as an image.
 
         Generate the document as an image based on the elements defined with other
@@ -272,6 +276,9 @@ class Document:
                                      item["border_color"],
                                      item["border_width"])
             elif item["type"] == "page_break":
+                # break if assigning to single file object
+                if file_object:
+                    break
                 image.save()
                 image_count = image_count + 1
                 if size:
@@ -280,7 +287,10 @@ class Document:
                 else:
                     image = _Image("file_name_{}".format(image_count),
                                    image_format, (self.w, self.h))
-        image.save()
+        if file_object:
+            image.save(file_object)
+        else:
+            image.save()
 
     def _validate_x_var(self, x):
         # Confirm x-coordinate is an integer and within document plane.

--- a/multiformat/multiformat.py
+++ b/multiformat/multiformat.py
@@ -199,19 +199,26 @@ class Document:
             "type": "page_break",
         })
 
-    def generate_pdf(self, file_name):
+    def generate_pdf(self, file_name, file_object=None):
         """Generate the document as a PDF.
 
         Generate the document as a PDF based on the elements defined with other
         methods.
 
+        PDF will be saved to the current directory if a file-like object is
+        not assigned to the file_object parameter.
+
         Args:
             file_name: name of the pdf file, without extension. (String)
-
+            file_object: optional file-like object to write to
         Returns:
             None
         """
-        pdf = _PDF(file_name, self.document_size, self.layout)
+        pdf = _PDF(
+            file_name,
+            self.document_size,
+            self.layout,
+            file_object=file_object)
         pdf.set_metadata(
             author=self.author, title=self.title, subject=self.subject)
         for item in self._document:
@@ -237,13 +244,17 @@ class Document:
                        file_object=None):
         """Generate the document as an image.
 
-        Generate the document as an image based on the elements defined with other
-        methods. Will create PNG, GIF, or JPEG images.
+        Generate the document as an image based on the elements defined with
+        other methods. Will create PNG, GIF, or JPEG images.
+
+        Image will be saved to the current directory if a file-like object is
+        not assigned to the file_object parameter.
 
         Args:
             file_name: name of the image file, without extension. (String)
             image_format: GIF, JPEG, PNG (String)
             size: Width and height of image in pixels (Integer, Integer)
+            file_object: optional file-like object to write to
 
         Returns:
             None


### PR DESCRIPTION
The ability to write documents to file-like objects is often required. For example, it is needed to serve files with Django. 

- adds option to write to file-like object with generate_image() and generate_pdf()